### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GoSkills - Claude Skills Management Tool
 
+[![Run in Smithery](https://smithery.ai/badge/skills/smallnest)](https://smithery.ai/skills?ns=smallnest&utm_source=github&utm_medium=badge)
+
+
 English | [简体中文](README_CN.md)
 
 A powerful command-line tool to parse, manage, and execute Claude Skill packages. GoSkills is designed according to the specifications found in the [official Claude documentation](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/).


### PR DESCRIPTION
## Add skill discoverability badge

Your 14 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/smallnest)](https://smithery.ai/skills?ns=smallnest&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.